### PR TITLE
Revert numpy version for docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@
 # Pull base image.
 FROM python:3.10.4-slim-bullseye
 
+# if GPU is needed
+#FROM tensorflow/tensorflow:2.9.1-gpu
+
 # Set environment variables.
 ENV PIP_DISABLE_PIP_VERSION_CHECK 1
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,6 +41,13 @@ services:
             - .:/Code
             - /Users/harold/Desktop/Test Archive:/Archive
 
+        # Allow access to GPU
+        #deploy:
+        #  resources:
+        #    reservations:
+        #      devices:
+        #        - capabilities: [gpu]
+
         environment:
 
             # Django secret key. DO NOT USE THE KEY BELOW FOR A PUBLIC

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,11 +23,11 @@ jsonschema==4.5.1
 keras==2.9.0
 Keras-Preprocessing==1.1.2
 libclang==14.0.1
-llvmlite==0.38.1
+llvmlite==0.39.0
 Markdown==3.3.7
 marshmallow==3.15.0
-numba==0.55.1
-numpy==1.21.6
+numba==0.56.0
+numpy==1.22.0
 oauthlib==3.2.0
 opt-einsum==3.3.0
 packaging==21.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ llvmlite==0.38.1
 Markdown==3.3.7
 marshmallow==3.15.0
 numba==0.55.1
-numpy==1.22.0
+numpy==1.21.6
 oauthlib==3.2.0
 opt-einsum==3.3.0
 packaging==21.3


### PR DESCRIPTION
I was having issues with the pinned `numpy` version (1.22.0) conflicting as follows, so this PR downgrades `numpy` to 1.21.6. The error is below.

```
#0 31.99 ERROR: Cannot install -r requirements.txt (line 19), -r requirements.txt (line 21), -r requirements.txt (line 24), -r requirements.txt (line 29) and numpy==1.22.0 because these package versions have conflicting dependencies.
#0 31.99 
#0 31.99 The conflict is caused by:
#0 31.99     The user requested numpy==1.22.0
#0 31.99     h5py 3.6.0 depends on numpy>=1.14.5
#0 31.99     jplephem 2.17 depends on numpy
#0 31.99     keras-preprocessing 1.1.2 depends on numpy>=1.9.1
#0 31.99     numba 0.55.1 depends on numpy<1.22 and >=1.18
#0 31.99 
#0 31.99 To fix this you could try to:
#0 31.99 1. loosen the range of package versions you've specified
#0 31.99 2. remove package versions to allow pip attempt to solve the dependency conflict
#0 31.99 
#0 31.99 ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```

It's very possible a better fix exists!